### PR TITLE
Fixed response value for manual interrupt in IDLE

### DIFF
--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -130,7 +130,7 @@ impl<T: Read + Write + Unpin + fmt::Debug> Handle<T> {
                 }
             }
 
-            Ok(IdleResponse::Timeout)
+            Ok(IdleResponse::ManualInterrupt)
         };
 
         (fut, interrupt)


### PR DESCRIPTION
`Handle::wait()` method returned `IdleResponse::Timeout` in case the idling process is manually canceled instead of `IdleResponse::ManualInterrrupt` (which is actually not used anywhere).

This PR fixes this behavior.