### PR TITLE
Refactor the imap-stream implementation to be more robust

### DIFF
--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -43,6 +43,12 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
     }
 
     pub async fn encode(&mut self, msg: Request) -> Result<(), io::Error> {
+        if self.closed {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "inner stream closed",
+            ));
+        }
         log::trace!(
             "encode: input: {:?}, {:?}",
             msg.0,


### PR DESCRIPTION
This builds on top of #31, which might as well still be merged (it's approved but I don't have permissions to merge).  It's commits are included.

This is a much larger refactor aiming at making the stream code easier to work with and reason about.  It helped me narrow down the bug in byte-pool.  The last commit which avoids sending data to the inner stream when closed is perhaps a little debatable.  I think it makes sense as explained in the commit message.

Commit messages which explain a lot more of the rationale:

Refactor buffering in imap-stream, fixing infinite loop

There was a bug in the underlying byte-pool library which reported an
incorrect amount of free space.  This allowed sometimes .poll_read()
to be called with a buffer with no capacity, resulted in an infinite
loop in .poll_next().

This commit improves safety by keeping better track of when the
underlying stream should be considered closed which avoids the
infinite loop. It also always clearly ensures there is space in the
buffer before entering .poll_read() so that we can be sure 0 bytes
read means the stream is closed.  Lastly keeping track of the closed
stream better avoids calling the stream when it already is closed,
something which should not be done, but we still had some buffered
responses to decode.

This also refactors and simplifies the whole implementation.  The
logic of what happens however is unchanged, in particular the way
blocks are created, moved, re-used etc is left identical.

- The state needed to keep is separated out into state of the
  ImapStream and state for the buffer management, now in the new
  Buffer struct.  This simplifies state management.

- The buffer was only using an end position so the start position
  could be removed.

- Whether a decode attempt should be made before reading more data is
  no longer kept as state itself.  Instead .maybe_decode() looks at
  the available data in the buffer and whether there is a known minium
  amount of data.  This is less state to track.

- The ImapStream.decode_needs state is only ever modified in the
  .decode() method.  Reducing the complexity of reasoning about it.

- The new ImapStream.closed state ensures that we still decode all
  already received data without accidentally polling the inner stream
  after it was closed.  It is also only ever manipulated in the
  .poll_next() method, keeping the complexity of reasoning about it
  small.


Do not try to send data when stream is closed

We know when the inner stream is closed, in this case it is safer and
more robust to no longer send requests to it.  In particular this is
cleaner when we still have responses buffered so the .poll_next()
method is still returning responses.