### PR TITLE
Fix response handling in authentication

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -19,11 +19,12 @@ fn main() -> Result<()> {
 
 async fn fetch_inbox_top(imap_server: &str, login: &str, password: &str) -> Result<Option<String>> {
     let tls = async_native_tls::TlsConnector::new();
+    let imap_addr = (imap_server, 993);
 
     // we pass in the imap_server twice to check that the server's TLS
     // certificate is valid for the imap_server we're connecting to.
-    let client = async_imap::connect((imap_server, 993), imap_server, tls).await?;
-    println!("-- connected to {}:{}", imap_server, 993);
+    let client = async_imap::connect(imap_addr, imap_server, tls).await?;
+    println!("-- connected to {}:{}", imap_addr.0, imap_addr.1);
 
     // the client we have here is unauthenticated.
     // to do anything useful with the e-mails, we need to log in

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -7,10 +7,10 @@ struct GmailOAuth2 {
     access_token: String,
 }
 
-impl async_imap::Authenticator for GmailOAuth2 {
+impl async_imap::Authenticator for &GmailOAuth2 {
     type Response = String;
-    #[allow(unused_variables)]
-    fn process(&self, data: &[u8]) -> Self::Response {
+
+    fn process(&mut self, _data: &[u8]) -> Self::Response {
         format!(
             "user={}\x01auth=Bearer {}\x01\x01",
             self.user, self.access_token

--- a/examples/idle.rs
+++ b/examples/idle.rs
@@ -21,11 +21,12 @@ fn main() -> Result<()> {
 
 async fn fetch_and_idle(imap_server: &str, login: &str, password: &str) -> Result<()> {
     let tls = async_native_tls::TlsConnector::new();
+    let imap_addr = (imap_server, 993);
 
     // we pass in the imap_server twice to check that the server's TLS
     // certificate is valid for the imap_server we're connecting to.
-    let client = async_imap::connect((imap_server, 993), imap_server, tls).await?;
-    println!("-- connected to {}:{}", imap_server, 993);
+    let client = async_imap::connect(imap_addr, imap_server, tls).await?;
+    println!("-- connected to {}:{}", imap_addr.0, imap_addr.1);
 
     // the client we have here is unauthenticated.
     // to do anything useful with the e-mails, we need to log in

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -6,5 +6,5 @@ pub trait Authenticator {
 
     /// Each base64-decoded server challenge is passed to `process`.
     /// The returned byte-string is base64-encoded and then sent back to the server.
-    fn process(&self, challenge: &[u8]) -> Self::Response;
+    fn process(&mut self, challenge: &[u8]) -> Self::Response;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -64,10 +64,6 @@ pub struct Client<T: Read + Write + Unpin + fmt::Debug> {
 pub struct Connection<T: Read + Write + Unpin + fmt::Debug> {
     pub(crate) stream: ImapStream<T>,
 
-    /// Enable debug mode for this connection so that all client-server interactions are printed to
-    /// `STDERR`.
-    pub debug: bool,
-
     /// Manages the request ids.
     pub(crate) request_ids: IdGenerator,
 }
@@ -192,7 +188,6 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Client<T> {
         Client {
             conn: Connection {
                 stream,
-                debug: false,
                 request_ids: IdGenerator::new(),
             },
         }
@@ -1542,7 +1537,7 @@ mod tests {
     #[async_std::test]
     async fn logout() {
         let response = b"A0001 OK Logout completed.\r\n".to_vec();
-        let command = format!("A0001 LOGOUT\r\n");
+        let command = "A0001 LOGOUT\r\n";
         let mock_stream = MockStream::new(response);
         let mut session = mock_session!(mock_stream);
         session.logout().await.unwrap();
@@ -2044,7 +2039,7 @@ mod tests {
     #[test]
     fn validate_newline() {
         if let Err(ref e) = validate_str("test\nstring") {
-            if let &Error::Validate(ref ve) = e {
+            if let Error::Validate(ref ve) = e {
                 if ve.0 == '\n' {
                     return;
                 }
@@ -2058,7 +2053,7 @@ mod tests {
     #[allow(unreachable_patterns)]
     fn validate_carriage_return() {
         if let Err(ref e) = validate_str("test\rstring") {
-            if let &Error::Validate(ref ve) = e {
+            if let Error::Validate(ref ve) = e {
                 if ve.0 == '\r' {
                     return;
                 }

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -207,7 +207,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
         self.session.run_command_untagged("DONE").await?;
         let sender = self.session.unsolicited_responses_tx.clone();
         self.session
-            .check_ok(self.id.expect("invalid setup"), Some(sender))
+            .check_done_ok(&self.id.expect("invalid setup"), Some(sender))
             .await?;
 
         Ok(self.session)

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -1,5 +1,5 @@
-use std::pin::Pin;
 use std::fmt;
+use std::pin::Pin;
 
 use async_std::io::{self, Read, Write};
 use async_std::prelude::*;
@@ -434,6 +434,9 @@ mod tests {
 
     #[test]
     fn test_buffer_debug() {
-        assert_eq!(format!("{:?}", Buffer::new()), r#"Buffer(<block>)"#);
+        assert_eq!(
+            format!("{:?}", Buffer::new()),
+            format!(r#"Buffer {{ used: 0, capacity: {} }}"#, Buffer::BLOCK_SIZE)
+        );
     }
 }

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -336,8 +336,7 @@ mod tests {
     fn test_buffer_write_read() {
         let mut buf = Buffer::new();
         let mut slice = buf.free_as_mut_slice();
-        slice.write(b"hello").unwrap();
-        std::mem::drop(slice);
+        slice.write_all(b"hello").unwrap();
         buf.extend_used(b"hello".len());
 
         let slice = &buf.block[..buf.used()];
@@ -409,14 +408,14 @@ mod tests {
     #[test]
     fn test_buffer_reset_with_data() {
         // This test identifies blocks by their size.
-        let data: [u8; 2 * Buffer::BLOCK_SIZE] = ['a' as u8; 2 * Buffer::BLOCK_SIZE];
+        let data: [u8; 2 * Buffer::BLOCK_SIZE] = [b'a'; 2 * Buffer::BLOCK_SIZE];
         let mut buf = Buffer::new();
         let block_size = buf.block.size();
         assert_eq!(block_size, Buffer::BLOCK_SIZE);
         buf.reset_with_data(&data);
         assert_ne!(buf.block.size(), block_size);
         assert_eq!(buf.block.size(), 3 * Buffer::BLOCK_SIZE);
-        assert!(buf.free_as_mut_slice().len() > 0);
+        assert!(!buf.free_as_mut_slice().is_empty());
 
         let data: [u8; 0] = [];
         let mut buf = Buffer::new();

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -1,4 +1,5 @@
 use std::pin::Pin;
+use std::fmt;
 
 use async_std::io::{self, Read, Write};
 use async_std::prelude::*;
@@ -150,7 +151,6 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
 }
 
 /// Abstraction around needed buffer management.
-#[derive(Debug)]
 struct Buffer {
     /// The buffer itself.
     block: Block<'static>,
@@ -263,6 +263,15 @@ impl Buffer {
     /// Return the block which backs this buffer.
     fn return_block(&mut self, block: Block<'static>) {
         self.block = block;
+    }
+}
+
+impl fmt::Debug for Buffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Buffer")
+            .field("used", &self.used())
+            .field("capacity", &self.block.size())
+            .finish()
     }
 }
 
@@ -421,5 +430,10 @@ mod tests {
         let mut buf = Buffer::new();
         buf.reset_with_data(&data);
         assert_eq!(buf.block.size(), Buffer::BLOCK_SIZE);
+    }
+
+    #[test]
+    fn test_buffer_debug() {
+        assert_eq!(format!("{:?}", Buffer::new()), r#"Buffer(<block>)"#);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -344,10 +344,9 @@ mod tests {
 
     #[async_std::test]
     async fn parse_capability_test() {
-        let expected_capabilities = vec!["IMAP4rev1", "STARTTLS", "AUTH=GSSAPI", "LOGINDISABLED"];
-        let responses = input_stream(&vec![
-            "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n",
-        ]);
+        let expected_capabilities = &["IMAP4rev1", "STARTTLS", "AUTH=GSSAPI", "LOGINDISABLED"];
+        let responses =
+            input_stream(&["* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n"]);
 
         let mut stream = async_std::stream::from_iter(responses);
         let (send, recv) = sync::channel(10);
@@ -364,8 +363,8 @@ mod tests {
     #[async_std::test]
     async fn parse_capability_case_insensitive_test() {
         // Test that "IMAP4REV1" (instead of "IMAP4rev1") is accepted
-        let expected_capabilities = vec!["IMAP4rev1", "STARTTLS"];
-        let responses = input_stream(&vec!["* CAPABILITY IMAP4REV1 STARTTLS\r\n"]);
+        let expected_capabilities = &["IMAP4rev1", "STARTTLS"];
+        let responses = input_stream(&["* CAPABILITY IMAP4REV1 STARTTLS\r\n"]);
         let mut stream = async_std::stream::from_iter(responses);
 
         let (send, recv) = sync::channel(10);
@@ -384,9 +383,7 @@ mod tests {
     #[should_panic]
     async fn parse_capability_invalid_test() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![
-            "* JUNK IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n",
-        ]);
+        let responses = input_stream(&["* JUNK IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n"]);
         let mut stream = async_std::stream::from_iter(responses);
 
         let id = RequestId("A0001".into());
@@ -399,7 +396,7 @@ mod tests {
     #[async_std::test]
     async fn parse_names_test() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec!["* LIST (\\HasNoChildren) \".\" \"INBOX\"\r\n"]);
+        let responses = input_stream(&["* LIST (\\HasNoChildren) \".\" \"INBOX\"\r\n"]);
         let mut stream = async_std::stream::from_iter(responses);
 
         let id = RequestId("A0001".into());
@@ -420,7 +417,7 @@ mod tests {
     #[async_std::test]
     async fn parse_fetches_empty() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![]);
+        let responses = input_stream(&[]);
         let mut stream = async_std::stream::from_iter(responses);
         let id = RequestId("a".into());
 
@@ -435,7 +432,7 @@ mod tests {
     #[async_std::test]
     async fn parse_fetches_test() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![
+        let responses = input_stream(&[
             "* 24 FETCH (FLAGS (\\Seen) UID 4827943)\r\n",
             "* 25 FETCH (FLAGS (\\Seen))\r\n",
         ]);
@@ -465,7 +462,7 @@ mod tests {
     async fn parse_fetches_w_unilateral() {
         // https://github.com/mattnenterprise/rust-imap/issues/81
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec!["* 37 FETCH (UID 74)\r\n", "* 1 RECENT\r\n"]);
+        let responses = input_stream(&["* 37 FETCH (UID 74)\r\n", "* 1 RECENT\r\n"]);
         let mut stream = async_std::stream::from_iter(responses);
         let id = RequestId("a".into());
 
@@ -483,7 +480,7 @@ mod tests {
     #[async_std::test]
     async fn parse_names_w_unilateral() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![
+        let responses = input_stream(&[
             "* LIST (\\HasNoChildren) \".\" \"INBOX\"\r\n",
             "* 4 EXPUNGE\r\n",
         ]);
@@ -509,14 +506,14 @@ mod tests {
     #[async_std::test]
     async fn parse_capabilities_w_unilateral() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![
+        let responses = input_stream(&[
             "* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI LOGINDISABLED\r\n",
             "* STATUS dev.github (MESSAGES 10 UIDNEXT 11 UIDVALIDITY 1408806928 UNSEEN 0)\r\n",
             "* 4 EXISTS\r\n",
         ]);
         let mut stream = async_std::stream::from_iter(responses);
 
-        let expected_capabilities = vec!["IMAP4rev1", "STARTTLS", "AUTH=GSSAPI", "LOGINDISABLED"];
+        let expected_capabilities = &["IMAP4rev1", "STARTTLS", "AUTH=GSSAPI", "LOGINDISABLED"];
 
         let id = RequestId("A0001".into());
         let capabilities = parse_capabilities(&mut stream, send, id).await.unwrap();
@@ -544,7 +541,7 @@ mod tests {
     #[async_std::test]
     async fn parse_ids_w_unilateral() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![
+        let responses = input_stream(&[
             "* SEARCH 23 42 4711\r\n",
             "* 1 RECENT\r\n",
             "* STATUS INBOX (MESSAGES 10 UIDNEXT 11 UIDVALIDITY 1408806928 UNSEEN 0)\r\n",
@@ -574,7 +571,7 @@ mod tests {
     #[async_std::test]
     async fn parse_ids_test() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec![
+        let responses = input_stream(&[
                 "* SEARCH 1600 1698 1739 1781 1795 1885 1891 1892 1893 1898 1899 1901 1911 1926 1932 1933 1993 1994 2007 2032 2033 2041 2053 2062 2063 2065 2066 2072 2078 2079 2082 2084 2095 2100 2101 2102 2103 2104 2107 2116 2120 2135 2138 2154 2163 2168 2172 2189 2193 2198 2199 2205 2212 2213 2221 2227 2267 2275 2276 2295 2300 2328 2330 2332 2333 2334\r\n",
                 "* SEARCH 2335 2336 2337 2338 2339 2341 2342 2347 2349 2350 2358 2359 2362 2369 2371 2372 2373 2374 2375 2376 2377 2378 2379 2380 2381 2382 2383 2384 2385 2386 2390 2392 2397 2400 2401 2403 2405 2409 2411 2414 2417 2419 2420 2424 2426 2428 2439 2454 2456 2467 2468 2469 2490 2515 2519 2520 2521\r\n",
             ]);
@@ -607,7 +604,7 @@ mod tests {
     #[async_std::test]
     async fn parse_ids_search() {
         let (send, recv) = sync::channel(10);
-        let responses = input_stream(&vec!["* SEARCH\r\n"]);
+        let responses = input_stream(&["* SEARCH\r\n"]);
         let mut stream = async_std::stream::from_iter(responses);
 
         let id = RequestId("A0001".into());


### PR DESCRIPTION
Closes #35 
- Auth responses being handled (sasl working now)
- Useless debug field removed **- breaking change**
- More unsolicited messages handled on auth **- breaking change**
- Consume mutable authenticators (to support SASL mechs better) **- breaking change**
- Improved client debug (buffer formatting was far too long)
- Fixed clippy warnings
