### PR TITLE
Update async-std and stop-token dependencies, migrate to stable channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ nom = "5.0"
 base64 = "0.13"
 chrono = "0.4"
 async-native-tls = { version = "0.3.3" }
-async-std = { version = "1.6.0", default-features = false, features = ["std"] }
+async-std = { version = "1.8.0", default-features = false, features = ["std"] }
 pin-utils = "0.1.0-alpha.4"
 futures = "0.3.0"
 rental = "0.5.5"
-stop-token = { version = "0.1.1", features = ["unstable"] }
+stop-token = "0.2"
 byte-pool = "0.2.2"
 lazy_static = "1.4.0"
 log = "0.4.8"
@@ -41,7 +41,7 @@ thiserror = "1.0.9"
 lettre_email = "0.9"
 pretty_assertions = "0.6.1"
 async-smtp = { version = "0.3.0" }
-async-std = { version = "1.6.0", default-features = false, features = ["std", "attributes"] }
+async-std = { version = "1.8.0", default-features = false, features = ["std", "attributes"] }
 
 [[example]]
 name = "basic"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,11 +10,11 @@ use crate::error::{Error, Result};
 use crate::types::ResponseData;
 use crate::types::*;
 
-pub(crate) fn parse_names<'a, T: Stream<Item = io::Result<ResponseData>> + Unpin + Send>(
-    stream: &'a mut T,
+pub(crate) fn parse_names<T: Stream<Item = io::Result<ResponseData>> + Unpin + Send>(
+    stream: &mut T,
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
-) -> impl Stream<Item = Result<Name>> + 'a + Send + Unpin {
+) -> impl Stream<Item = Result<Name>> + '_ + Send + Unpin {
     use futures::{FutureExt, StreamExt};
 
     StreamExt::filter_map(
@@ -56,11 +56,11 @@ fn filter_sync(res: &io::Result<ResponseData>, command_tag: &RequestId) -> bool 
     }
 }
 
-pub(crate) fn parse_fetches<'a, T: Stream<Item = io::Result<ResponseData>> + Unpin + Send>(
-    stream: &'a mut T,
+pub(crate) fn parse_fetches<T: Stream<Item = io::Result<ResponseData>> + Unpin + Send>(
+    stream: &mut T,
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
-) -> impl Stream<Item = Result<Fetch>> + 'a + Send + Unpin {
+) -> impl Stream<Item = Result<Fetch>> + '_ + Send + Unpin {
     use futures::{FutureExt, StreamExt};
 
     StreamExt::filter_map(
@@ -85,11 +85,11 @@ pub(crate) fn parse_fetches<'a, T: Stream<Item = io::Result<ResponseData>> + Unp
     )
 }
 
-pub(crate) fn parse_expunge<'a, T: Stream<Item = io::Result<ResponseData>> + Unpin + Send>(
-    stream: &'a mut T,
+pub(crate) fn parse_expunge<T: Stream<Item = io::Result<ResponseData>> + Unpin + Send>(
+    stream: &mut T,
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
-) -> impl Stream<Item = Result<u32>> + 'a + Send {
+) -> impl Stream<Item = Result<u32>> + '_ + Send {
     use futures::StreamExt;
 
     StreamExt::filter_map(
@@ -113,8 +113,8 @@ pub(crate) fn parse_expunge<'a, T: Stream<Item = io::Result<ResponseData>> + Unp
     )
 }
 
-pub(crate) async fn parse_capabilities<'a, T: Stream<Item = io::Result<ResponseData>> + Unpin>(
-    stream: &'a mut T,
+pub(crate) async fn parse_capabilities<T: Stream<Item = io::Result<ResponseData>> + Unpin>(
+    stream: &mut T,
     unsolicited: channel::Sender<UnsolicitedResponse>,
     command_tag: RequestId,
 ) -> Result<Capabilities> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -291,7 +291,7 @@ pub(crate) async fn handle_unilateral(
 
     match res.parsed() {
         Response::MailboxData(MailboxDatum::Status { mailbox, status }) => {
-            let _ = unsolicited
+            unsolicited
                 .send(UnsolicitedResponse::Status {
                     mailbox: (*mailbox).into(),
                     attributes: status
@@ -307,23 +307,32 @@ pub(crate) async fn handle_unilateral(
                         })
                         .collect(),
                 })
-                .await; //TODO: decide what to do with result
+                .await
+                .expect("Channel closed unexpectedly");
         }
         Response::MailboxData(MailboxDatum::Recent(n)) => {
-            //TODO: decide what to do with result
-            let _ = unsolicited.send(UnsolicitedResponse::Recent(*n)).await;
+            unsolicited
+                .send(UnsolicitedResponse::Recent(*n))
+                .await
+                .expect("Channel closed unexpectedly");
         }
         Response::MailboxData(MailboxDatum::Exists(n)) => {
-            //TODO: decide what to do with result
-            let _ = unsolicited.send(UnsolicitedResponse::Exists(*n)).await;
+            unsolicited
+                .send(UnsolicitedResponse::Exists(*n))
+                .await
+                .expect("Channel closed unexpectedly");
         }
         Response::Expunge(n) => {
-            //TODO: decide what to do with result
-            let _ = unsolicited.send(UnsolicitedResponse::Expunge(*n)).await;
+            unsolicited
+                .send(UnsolicitedResponse::Expunge(*n))
+                .await
+                .expect("Channel closed unexpectedly");
         }
         _ => {
-            //TODO: decide what to do with result
-            let _ = unsolicited.send(UnsolicitedResponse::Other(res)).await;
+            unsolicited
+                .send(UnsolicitedResponse::Other(res))
+                .await
+                .expect("Channel closed unexpectedly");
         }
     }
 }


### PR DESCRIPTION
Updated `async-std` and `stop-token` dependencies.
The new `async-std` stabilized the channel api, and relocated them, so I migrated from `async_std::sync` to the new namespace `async_std::channel`.

The `send()` methods in the new stable channel api now returns `Result`s. I didn't want to assume what to best do with these, so I added TODOs.