### PR TITLE
Bump version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-imap"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["dignifiedquire <me@dignifiedquire.com>"]
 documentation = "https://docs.rs/async-imap/"
 repository = "https://github.com/async-email/async-imap"


### PR DESCRIPTION
@dignifiedquire would be good to get a new release out with the bumped async-std 1.8 dependency.  async-imap is currently responsible for pulling in a second async-std version in a few places.  You could also give me crates.io perms and then I can do the entire release ;)