### PR TITLE
update imap proto to 1.14.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ is-it-maintained-open-issues = { repository = "async-email/async-imap" }
 default = []
 
 [dependencies]
-imap-proto = "0.14.2"
+imap-proto = "0.14.3"
 nom = "6.0"
 base64 = "0.13"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ is-it-maintained-open-issues = { repository = "async-email/async-imap" }
 default = []
 
 [dependencies]
-imap-proto = "0.11"
-nom = "5.0"
+imap-proto = "0.14"
+nom = "6.0"
 base64 = "0.13"
 chrono = "0.4"
 async-native-tls = { version = "0.3.3" }
 async-std = { version = "1.8.0", default-features = false, features = ["std"] }
 pin-utils = "0.1.0-alpha.4"
-futures = "0.3.0"
+futures = "0.3.15"
 rental = "0.5.5"
 stop-token = "0.2"
 byte-pool = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ is-it-maintained-open-issues = { repository = "async-email/async-imap" }
 default = []
 
 [dependencies]
-imap-proto = "0.14"
+imap-proto = "0.14.2"
 nom = "6.0"
 base64 = "0.13"
 chrono = "0.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -318,7 +318,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Client<T> {
                     Response::Continue { information, .. } => {
                         let challenge = if let Some(text) = information {
                             ok_or_unauth_client_err!(
-                                base64::decode(text).map_err(|e| Error::Parse(
+                                base64::decode(text.as_ref()).map_err(|e| Error::Parse(
                                     ParseError::Authentication((*text).to_string(), Some(e))
                                 )),
                                 self
@@ -1347,7 +1347,7 @@ impl<T: Read + Write + Unpin + fmt::Debug> Connection<T> {
                 tag,
             } = response.parsed()
             {
-                self.check_status_ok(status, code.as_ref(), *information)?;
+                self.check_status_ok(status, code.as_ref(), information.as_deref())?;
 
                 if tag == id {
                     return Ok(());
@@ -1412,6 +1412,7 @@ mod tests {
     use super::super::error::Result;
     use super::super::mock_stream::MockStream;
     use super::*;
+    use std::borrow::Cow;
 
     use async_std::sync::{Arc, Mutex};
     use imap_proto::Status;
@@ -1462,7 +1463,7 @@ mod tests {
             &Response::Data {
                 status: Status::Ok,
                 code: None,
-                information: Some("Dovecot ready."),
+                information: Some(Cow::Borrowed("Dovecot ready.")),
             }
         );
     }

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -181,7 +181,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
                         if let Status::Bad = status {
                             return Err(io::Error::new(
                                 io::ErrorKind::ConnectionRefused,
-                                information.unwrap().to_string(),
+                                information.as_ref().unwrap().to_string(),
                             )
                             .into());
                         }

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -120,7 +120,7 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
                 }
                 Err(nom::Err::Incomplete(Needed::Size(min))) => {
                     log::trace!("decode: incomplete data, need minimum {} bytes", min);
-                    self.decode_needs = Some(min);
+                    self.decode_needs = Some(usize::from(min));
                     Err(None)
                 }
                 Err(nom::Err::Incomplete(_)) => {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -240,6 +240,8 @@ pub(crate) async fn parse_mailbox<T: Stream<Item = io::Result<ResponseData>> + U
                 MailboxDatum::MetadataSolicited { .. } => {}
                 MailboxDatum::MetadataUnsolicited { .. } => {}
                 MailboxDatum::Search { .. } => {}
+                MailboxDatum::Sort { .. } => {}
+                _ => {}
             },
             _ => {
                 handle_unilateral(resp, unsolicited.clone()).await;
@@ -293,7 +295,7 @@ pub(crate) async fn handle_unilateral(
         Response::MailboxData(MailboxDatum::Status { mailbox, status }) => {
             unsolicited
                 .send(UnsolicitedResponse::Status {
-                    mailbox: (*mailbox).into(),
+                    mailbox: (mailbox.as_ref()).into(),
                     attributes: status
                         .iter()
                         .map(|s| match s {
@@ -304,6 +306,7 @@ pub(crate) async fn handle_unilateral(
                             StatusAttribute::UidNext(a) => StatusAttribute::UidNext(*a),
                             StatusAttribute::UidValidity(a) => StatusAttribute::UidValidity(*a),
                             StatusAttribute::Unseen(a) => StatusAttribute::Unseen(*a),
+                            _ => unimplemented!(),
                         })
                         .collect(),
                 })

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -298,16 +298,7 @@ pub(crate) async fn handle_unilateral(
                     mailbox: (mailbox.as_ref()).into(),
                     attributes: status
                         .iter()
-                        .map(|s| match s {
-                            // Fake clone
-                            StatusAttribute::HighestModSeq(a) => StatusAttribute::HighestModSeq(*a),
-                            StatusAttribute::Messages(a) => StatusAttribute::Messages(*a),
-                            StatusAttribute::Recent(a) => StatusAttribute::Recent(*a),
-                            StatusAttribute::UidNext(a) => StatusAttribute::UidNext(*a),
-                            StatusAttribute::UidValidity(a) => StatusAttribute::UidValidity(*a),
-                            StatusAttribute::Unseen(a) => StatusAttribute::Unseen(*a),
-                            _ => unimplemented!(),
-                        })
+                        .map(|s| s.clone())
                         .collect(),
                 })
                 .await

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -296,10 +296,7 @@ pub(crate) async fn handle_unilateral(
             unsolicited
                 .send(UnsolicitedResponse::Status {
                     mailbox: (mailbox.as_ref()).into(),
-                    attributes: status
-                        .iter()
-                        .map(|s| s.clone())
-                        .collect(),
+                    attributes: status.iter().cloned().collect(),
                 })
                 .await
                 .expect("Channel closed unexpectedly");

--- a/src/types/capabilities.rs
+++ b/src/types/capabilities.rs
@@ -20,8 +20,8 @@ impl From<&CapabilityRef<'_>> for Capability {
     fn from(c: &CapabilityRef<'_>) -> Self {
         match c {
             CapabilityRef::Imap4rev1 => Capability::Imap4rev1,
-            CapabilityRef::Auth(s) => Capability::Auth((*s).into()),
-            CapabilityRef::Atom(s) => Capability::Atom((*s).into()),
+            CapabilityRef::Auth(s) => Capability::Auth(s.clone().into_owned()),
+            CapabilityRef::Atom(s) => Capability::Atom(s.clone().into_owned()),
         }
     }
 }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -63,7 +63,7 @@ impl Fetch {
                 .iter()
                 .filter_map(|attr| match attr {
                     AttributeValue::Flags(raw_flags) => {
-                        Some(raw_flags.iter().map(|s| Flag::from(*s)))
+                        Some(raw_flags.iter().map(|s| Flag::from(s.as_ref())))
                     }
                     _ => None,
                 })
@@ -85,7 +85,7 @@ impl Fetch {
                         data: Some(hdr),
                         ..
                     }
-                    | AttributeValue::Rfc822Header(Some(hdr)) => Some(*hdr),
+                    | AttributeValue::Rfc822Header(Some(hdr)) => Some(hdr.as_ref()),
                     _ => None,
                 })
                 .next()
@@ -107,7 +107,7 @@ impl Fetch {
                         data: Some(body),
                         ..
                     }
-                    | AttributeValue::Rfc822(Some(body)) => Some(*body),
+                    | AttributeValue::Rfc822(Some(body)) => Some(body.as_ref()),
                     _ => None,
                 })
                 .next()
@@ -130,7 +130,7 @@ impl Fetch {
                         data: Some(body),
                         ..
                     }
-                    | AttributeValue::Rfc822Text(Some(body)) => Some(*body),
+                    | AttributeValue::Rfc822Text(Some(body)) => Some(body.as_ref()),
                     _ => None,
                 })
                 .next()
@@ -173,7 +173,7 @@ impl Fetch {
                         section: Some(sp),
                         data: Some(data),
                         ..
-                    } if sp == path => Some(*data),
+                    } if sp == path => Some(data.as_ref()),
                     _ => None,
                 })
                 .next()
@@ -191,7 +191,7 @@ impl Fetch {
             attrs
                 .iter()
                 .filter_map(|av| match av {
-                    AttributeValue::InternalDate(date_time) => Some(*date_time),
+                    AttributeValue::InternalDate(date_time) => Some(date_time.as_ref()),
                     _ => None,
                 })
                 .next()

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -90,8 +90,11 @@ impl Name {
                 delimiter,
                 name,
             }) => InnerName {
-                attributes: flags.iter().map(|s| NameAttribute::from(*s)).collect(),
-                delimiter: *delimiter,
+                attributes: flags
+                    .iter()
+                    .map(|s| NameAttribute::from(s.as_ref()))
+                    .collect(),
+                delimiter: delimiter.as_deref(),
                 name,
             },
             _ => panic!("cannot construct from non mailbox data"),

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::time::Duration;
 
 use async_imap::Session;
@@ -171,17 +172,17 @@ fn inbox() {
         assert_ne!(fetch.uid, None);
         assert_eq!(fetch.size, Some(21));
         let e = fetch.envelope().unwrap();
-        assert_eq!(e.subject, Some(&b"My first e-mail"[..]));
+        assert_eq!(e.subject, Some(Cow::Borrowed(&b"My first e-mail"[..])));
         assert_ne!(e.from, None);
         assert_eq!(e.from.as_ref().unwrap().len(), 1);
         let from = &e.from.as_ref().unwrap()[0];
-        assert_eq!(from.mailbox, Some(&b"sender"[..]));
-        assert_eq!(from.host, Some(&b"localhost"[..]));
+        assert_eq!(from.mailbox, Some(Cow::Borrowed(&b"sender"[..])));
+        assert_eq!(from.host, Some(Cow::Borrowed(&b"localhost"[..])));
         assert_ne!(e.to, None);
         assert_eq!(e.to.as_ref().unwrap().len(), 1);
         let to = &e.to.as_ref().unwrap()[0];
-        assert_eq!(to.mailbox, Some(&b"inbox"[..]));
-        assert_eq!(to.host, Some(&b"localhost"[..]));
+        assert_eq!(to.mailbox, Some(Cow::Borrowed(&b"inbox"[..])));
+        assert_eq!(to.host, Some(Cow::Borrowed(&b"localhost"[..])));
         let date_opt = fetch.internal_date();
         assert!(date_opt.is_some());
 
@@ -247,7 +248,7 @@ fn inbox_uid() {
         let fetch = &fetch[0];
         assert_eq!(fetch.uid, Some(uid));
         let e = fetch.envelope().unwrap();
-        assert_eq!(e.subject, Some(&b"My first e-mail"[..]));
+        assert_eq!(e.subject, Some(Cow::Borrowed(&b"My first e-mail"[..])));
         let date_opt = fetch.internal_date();
         assert!(date_opt.is_some());
 


### PR DESCRIPTION
- [x] wait until there is a new imap-proto version, including https://github.com/djc/tokio-imap/pull/125 so we can replace the fake-clone and with it the potential `unimplemented!` panic