### PR TITLE
Export crates used in the public interface of the crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Below is a basic client example. See the `examples/` directory for more.
 
 ```rust
 use async_std::prelude::*;
-use async_imap::error::Result;
+use async_imap::{TlsConnector, error::Result};
 
 async fn fetch_inbox_top() -> Result<Option<String>> {
     let domain = "imap.example.com";
-    let tls = async_native_tls::TlsConnector::new();
+    let tls = TlsConnector::new();
 
     // we pass in the domain twice to check that the server's TLS
     // certificate is valid for the domain we're connecting to.

--- a/examples/src/bin/basic.rs
+++ b/examples/src/bin/basic.rs
@@ -1,6 +1,9 @@
 use std::env;
 
-use async_imap::error::{Error, Result};
+use async_imap::{
+    error::{Error, Result},
+    types::TlsConnector,
+};
 use futures::TryStreamExt;
 
 #[cfg_attr(feature = "runtime-tokio", tokio::main)]
@@ -18,7 +21,7 @@ async fn main() -> Result<()> {
 }
 
 async fn fetch_inbox_top(imap_server: &str, login: &str, password: &str) -> Result<Option<String>> {
-    let tls = async_native_tls::TlsConnector::new();
+    let tls = TlsConnector::new();
     let imap_addr = (imap_server, 993);
 
     // we pass in the imap_server twice to check that the server's TLS

--- a/examples/src/bin/futures.rs
+++ b/examples/src/bin/futures.rs
@@ -1,6 +1,9 @@
 use std::env;
 
-use async_imap::error::{Error, Result};
+use async_imap::{
+    error::{Error, Result},
+    types::TlsConnector,
+};
 use futures::TryStreamExt;
 
 fn main() -> Result<()> {
@@ -18,7 +21,7 @@ fn main() -> Result<()> {
 }
 
 async fn fetch_inbox_top(imap_server: &str, login: &str, password: &str) -> Result<Option<String>> {
-    let tls = async_native_tls::TlsConnector::new();
+    let tls = TlsConnector::new();
 
     // we pass in the imap_server twice to check that the server's TLS
     // certificate is valid for the imap_server we're connecting to.

--- a/examples/src/bin/gmail_oauth2.rs
+++ b/examples/src/bin/gmail_oauth2.rs
@@ -1,4 +1,4 @@
-use async_imap::error::Result;
+use async_imap::{error::Result, types::TlsConnector};
 use futures::StreamExt;
 
 struct GmailOAuth2 {
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     let domain = "imap.gmail.com";
     let port = 993;
     let socket_addr = (domain, port);
-    let tls = async_native_tls::TlsConnector::new();
+    let tls = TlsConnector::new();
     let client = async_imap::connect(socket_addr, domain, tls).await?;
 
     let mut imap_session = match client.authenticate("XOAUTH2", &gmail_auth).await {

--- a/examples/src/bin/idle.rs
+++ b/examples/src/bin/idle.rs
@@ -1,8 +1,11 @@
 use std::env;
 use std::time::Duration;
 
-use async_imap::error::{Error, Result};
-use async_imap::extensions::idle::IdleResponse::*;
+use async_imap::{
+    error::{Error, Result},
+    extensions::idle::IdleResponse::*,
+    types::TlsConnector,
+};
 use futures::StreamExt;
 
 #[cfg(feature = "runtime-async-std")]
@@ -25,7 +28,7 @@ async fn main() -> Result<()> {
 }
 
 async fn fetch_and_idle(imap_server: &str, login: &str, password: &str) -> Result<()> {
-    let tls = async_native_tls::TlsConnector::new();
+    let tls = TlsConnector::new();
     let imap_addr = (imap_server, 993);
 
     // we pass in the imap_server twice to check that the server's TLS

--- a/examples/src/bin/integration.rs
+++ b/examples/src/bin/integration.rs
@@ -1,17 +1,19 @@
 use std::borrow::Cow;
 use std::time::Duration;
 
-use async_imap::Session;
-use async_native_tls::TlsConnector;
+use async_imap::{
+    types::{TcpStream, TlsConnector, TlsStream},
+    Session,
+};
 use async_smtp::ServerAddress;
 #[cfg(feature = "runtime-async-std")]
-use async_std::{net::TcpStream, task, task::sleep};
+use async_std::{task, task::sleep};
 use futures::{StreamExt, TryStreamExt};
 #[cfg(feature = "runtime-tokio")]
-use tokio::{net::TcpStream, task, time::sleep};
+use tokio::{task, time::sleep};
 
-fn native_tls() -> async_native_tls::TlsConnector {
-    async_native_tls::TlsConnector::new()
+fn native_tls() -> TlsConnector {
+    TlsConnector::new()
         .danger_accept_invalid_certs(true)
         .danger_accept_invalid_hostnames(true)
 }
@@ -26,7 +28,7 @@ fn test_host() -> String {
     std::env::var("TEST_HOST").unwrap_or_else(|_| "127.0.0.1".into())
 }
 
-async fn session(user: &str) -> Session<async_native_tls::TlsStream<TcpStream>> {
+async fn session(user: &str) -> Session<TlsStream<TcpStream>> {
     async_imap::connect(&format!("{}:3993", test_host()), "imap.example.com", tls())
         .await
         .unwrap()

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,11 +5,10 @@ use std::pin::Pin;
 use std::str;
 
 use async_channel::{self as channel, bounded};
-use async_native_tls::{TlsConnector, TlsStream};
 #[cfg(feature = "runtime-async-std")]
 use async_std::{
     io::{Read, Write, WriteExt},
-    net::{TcpStream, ToSocketAddrs},
+    net::ToSocketAddrs,
 };
 use extensions::id::{format_identification, parse_id};
 use extensions::quota::parse_get_quota_root;
@@ -18,7 +17,7 @@ use imap_proto::{RequestId, Response};
 #[cfg(feature = "runtime-tokio")]
 use tokio::{
     io::{AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt},
-    net::{TcpStream, ToSocketAddrs},
+    net::ToSocketAddrs,
 };
 
 use super::authenticator::Authenticator;
@@ -122,7 +121,7 @@ impl<T: Read + Write + Unpin + fmt::Debug> DerefMut for Session<T> {
 /// # fn main() -> async_imap::error::Result<()> {
 /// # async_std::task::block_on(async {
 ///
-/// let tls = async_native_tls::TlsConnector::new();
+/// let tls = async_imap::types::TlsConnector::new();
 /// let client = async_imap::connect(("imap.example.org", 993), "imap.example.org", tls).await?;
 ///
 /// # Ok(())
@@ -219,7 +218,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Client<T> {
     /// # fn main() -> async_imap::error::Result<()> {
     /// # async_std::task::block_on(async {
     ///
-    /// let tls = async_native_tls::TlsConnector::new();
+    /// let tls = async_imap::types::TlsConnector::new();
     /// let client = async_imap::connect(
     ///     ("imap.example.org", 993),
     ///     "imap.example.org",
@@ -284,7 +283,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Client<T> {
     ///     };
     ///
     ///     let domain = "imap.example.com";
-    ///     let tls = async_native_tls::TlsConnector::new();
+    ///     let tls = async_imap::types::TlsConnector::new();
     ///     let client = async_imap::connect((domain, 993), domain, tls).await?;
     ///     match client.authenticate("XOAUTH2", &auth).await {
     ///         Ok(session) => {

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -22,7 +22,7 @@ use tokio::{
 use crate::client::Session;
 use crate::error::Result;
 use crate::parse::handle_unilateral;
-use crate::types::ResponseData;
+use crate::types::{ResponseData, StopSource};
 
 /// `Handle` allows a client to block waiting for changes to the remote mailbox.
 ///
@@ -106,12 +106,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
 
     /// Start listening to the server side resonses.
     /// Must be called after [Handle::init].
-    pub fn wait(
-        &mut self,
-    ) -> (
-        impl Future<Output = Result<IdleResponse>> + '_,
-        stop_token::StopSource,
-    ) {
+    pub fn wait(&mut self) -> (impl Future<Output = Result<IdleResponse>> + '_, StopSource) {
         assert!(
             self.id.is_some(),
             "Cannot listen to response without starting IDLE"
@@ -150,10 +145,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
     pub fn wait_with_timeout(
         &mut self,
         dur: Duration,
-    ) -> (
-        impl Future<Output = Result<IdleResponse>> + '_,
-        stop_token::StopSource,
-    ) {
+    ) -> (impl Future<Output = Result<IdleResponse>> + '_, StopSource) {
         assert!(
             self.id.is_some(),
             "Cannot listen to response without starting IDLE"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,11 @@
 //!
 //! ```no_run
 //! use futures::prelude::*;
-//! use async_imap::error::Result;
+//! use async_imap::{types::TlsConnector, error::Result};
 //!
 //! async fn fetch_inbox_top() -> Result<Option<String>> {
 //!     let domain = "imap.example.com";
-//!     let tls = async_native_tls::TlsConnector::new();
+//!     let tls = TlsConnector::new();
 //!
 //!     // we pass in the domain twice to check that the server's TLS
 //!     // certificate is valid for the domain we're connecting to.

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -1,10 +1,10 @@
-use chrono::{DateTime, FixedOffset};
+use chrono::DateTime;
 use imap_proto::types::{
     AttributeValue, BodyStructure, Envelope, MessageSection, Response, SectionPath,
 };
 
 use super::{Flag, Seq, Uid};
-use crate::types::ResponseData;
+use crate::types::{FixedOffsetDateTime, ResponseData};
 
 /// Format of Date and Time as defined RFC3501.
 /// See `date-time` element in [Formal Syntax](https://tools.ietf.org/html/rfc3501#section-9)
@@ -194,7 +194,7 @@ impl Fetch {
     ///
     /// See [section 2.3.3 of RFC 3501](https://tools.ietf.org/html/rfc3501#section-2.3.3) for
     /// details.
-    pub fn internal_date(&self) -> Option<DateTime<FixedOffset>> {
+    pub fn internal_date(&self) -> Option<FixedOffsetDateTime> {
         if let Response::Fetch(_, attrs) = self.response.parsed() {
             attrs
                 .iter()

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -213,6 +213,10 @@ pub(crate) use self::response_data::ResponseData;
 mod request;
 pub(crate) use self::request::Request;
 
+// Reexport types used in the public API
+mod thirdparty;
+pub use self::thirdparty::*;
+
 mod quota;
 pub use self::quota::*;
 

--- a/src/types/thirdparty.rs
+++ b/src/types/thirdparty.rs
@@ -1,0 +1,23 @@
+//! Contains types that are from third-party dependencies that are used in the public API
+
+use chrono::{DateTime, FixedOffset};
+
+/// TlsStream re-exports [`async_native_tls::TlsStream`].
+pub type TlsStream<T> = async_native_tls::TlsStream<T>;
+
+#[cfg(feature = "runtime-async-std")]
+/// TcpStream re-exports [`async_std::net::TcpStream`].
+pub type TcpStream = async_std::net::TcpStream;
+
+#[cfg(feature = "runtime-tokio")]
+/// TcpStream re-exports [`tokio::net::TcpStream`].
+pub type TcpStream = tokio::net::TcpStream;
+
+/// TlsConnector re-exports [`async_native_tls::TlsConnector`].
+pub type TlsConnector = async_native_tls::TlsConnector;
+
+/// FixedOffsetDateTime is an alias for a fixed-offset ([`FixedOffset`]) [`DateTime`]
+pub type FixedOffsetDateTime = DateTime<FixedOffset>;
+
+/// StopSource re-exports [`stop_token::StopSource`]
+pub type StopSource = stop_token::StopSource;


### PR DESCRIPTION
There are a bunch of types returned from the public interface of the crate that are not re-exported. For instance, `connect` returns a `Result<Client<TlsStream<TcpStream>`, but does not export these types, making it difficult to express this type in code that depends on this library. Originally, my solution was to directly depend on these crates, but that means my crate must depend on exactly the same version as this crate, which is unfortunate.

I've gone through the docs and re-exported the necessary crates (though it's possible I've missed one, of course).