### PR TITLE
chore: disable oldtime feature of chrono crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ runtime-tokio = ["tokio", "async-native-tls/runtime-tokio"]
 imap-proto = "0.16.1"
 nom = "7.0"
 base64 = "0.13"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 pin-utils = "0.1.0-alpha.4"
 futures = "0.3.15"
 ouroboros = "0.15"


### PR DESCRIPTION
oldtime feature is enabled by chrono by default
but is advised to be disabled by chrono readme.