### PR TITLE
Implement AsMut for session::Session and idle::Handle

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -57,6 +57,14 @@ impl<T: Read + Write + Unpin + fmt::Debug> Unpin for Session<T> {}
 impl<T: Read + Write + Unpin + fmt::Debug> Unpin for Client<T> {}
 impl<T: Read + Write + Unpin + fmt::Debug> Unpin for Connection<T> {}
 
+// Make it possible to access the inner connection and modify its settings, such as read/write
+// timeouts.
+impl<T: Read + Write + Unpin + fmt::Debug> AsMut<T> for Session<T> {
+    fn as_mut(&mut self) -> &mut T {
+        self.conn.stream.as_mut()
+    }
+}
+
 /// An (unauthenticated) handle to talk to an IMAP server. This is what you get when first
 /// connecting. A succesfull call to [`Client::login`] or [`Client::authenticate`] will return a
 /// [`Session`] instance that provides the usual IMAP methods.

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -97,6 +97,14 @@ pub enum IdleResponse {
     NewData(ResponseData),
 }
 
+// Make it possible to access the inner connection and modify its settings, such as read/write
+// timeouts.
+impl<T: Read + Write + Unpin + fmt::Debug> AsMut<T> for Handle<T> {
+    fn as_mut(&mut self) -> &mut T {
+        self.session.conn.stream.as_mut()
+    }
+}
+
 impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
     unsafe_pinned!(session: Session<T>);
 


### PR DESCRIPTION
This allows accessing inner stream and tweak its settings,
for example disabling the read timeout during IDLE.