### PR TITLE
Make async-native-tls dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ is-it-maintained-open-issues = { repository = "async-email/async-imap" }
 [features]
 default = ["runtime-async-std"]
 
-runtime-async-std = ["async-std", "async-native-tls/runtime-async-std"]
-runtime-tokio = ["tokio", "async-native-tls/runtime-tokio"]
+runtime-async-std = ["async-std", "async-native-tls?/runtime-async-std"]
+runtime-tokio = ["tokio", "async-native-tls?/runtime-tokio"]
 
 [dependencies]
 imap-proto = "0.16.1"
@@ -39,9 +39,9 @@ log = "0.4.8"
 thiserror = "1.0.9"
 async-channel = "1.6.1"
 
-async-native-tls = { version = "0.4", default-features = false }
+async-native-tls = { version = "0.4", default-features = false, optional = true }
 async-std = { version = "1.8.0", default-features = false, features = ["std"], optional = true }
-tokio = { version = "1", features = ["net", "sync", "time"], optional = true }
+tokio = { version = "1", features = ["net", "sync", "time", "io-util"], optional = true }
 
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     #[error("validate: {0}")]
     Validate(#[from] ValidateError),
     /// `async_native_tls` error
+    #[cfg(feature = "async-native-tls")]
     #[error("async_native_tls: {0}")]
     NativeTlsError(#[from] async_native_tls::Error),
     /// Error appending an e-mail.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! use futures::prelude::*;
 //! use async_imap::error::Result;
 //!
+//! #[cfg(feature = "async-native-tls")]
 //! async fn fetch_inbox_top() -> Result<Option<String>> {
 //!     let domain = "imap.example.com";
 //!     let tls = async_native_tls::TlsConnector::new();


### PR DESCRIPTION
It is still possible to make connections using Rustls or without TLS outside the library.