### PR TITLE
Do not generate artificial "broken pipe" errors

### DIFF
--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -48,12 +48,6 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
     }
 
     pub async fn encode(&mut self, msg: Request) -> Result<(), io::Error> {
-        if self.closed {
-            return Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "inner stream closed",
-            ));
-        }
         log::trace!(
             "encode: input: {:?}, {:?}",
             msg.0,


### PR DESCRIPTION
`closed` flag is set when there is no more data to read from the stream. It does not mean that no more requests can be written into the stream. If the stream is closed for writing, `write_all` call will return this error, there is no need to emulate it.