### PR TITLE
fix: parse NIL metadata response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ runtime-async-std = ["async-std"]
 runtime-tokio = ["tokio"]
 
 [dependencies]
-imap-proto = "0.16.1"
+imap-proto = "0.16.4"
 nom = "7.0"
 base64 = "0.21"
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2441,5 +2441,27 @@ mod tests {
                 "mailto:root@nine.testrun.org"
             );
         }
+
+        {
+            let response = b"* METADATA \"\" (/shared/comment NIL /shared/admin NIL)\r\n\
+                A0001 OK OK Getmetadata completed (0.001 + 0.000 secs).\r\n"
+                .to_vec();
+
+            let mock_stream = MockStream::new(response);
+            let mut session = mock_session!(mock_stream);
+            let metadata = session
+                .get_metadata("", "", "(/shared/comment /shared/admin)")
+                .await
+                .unwrap();
+            assert_eq!(
+                session.stream.inner.written_buf,
+                b"A0001 GETMETADATA \"\" (/shared/comment /shared/admin)\r\n".to_vec()
+            );
+            assert_eq!(metadata.len(), 2);
+            assert_eq!(metadata[0].entry, "/shared/comment");
+            assert_eq!(metadata[0].value, None);
+            assert_eq!(metadata[1].entry, "/shared/admin");
+            assert_eq!(metadata[1].value, None);
+        }
     }
 }


### PR DESCRIPTION
Upstream fix: https://github.com/djc/tokio-imap/pull/159