### PR TITLE
Print unparseable input as a string

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2470,4 +2470,24 @@ mod tests {
             assert_eq!(metadata[1].value, None);
         }
     }
+
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    async fn test_parsing_error() {
+        // Simulate someone connecting to SMTP server with IMAP client.
+        let response = b"220 mail.example.org ESMTP Postcow\r\n".to_vec();
+        let command = "A0001 NOOP\r\n";
+        let mock_stream = MockStream::new(response);
+        let mut session = mock_session!(mock_stream);
+        assert!(session
+            .noop()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("220 mail.example.org ESMTP Postcow"));
+        assert!(
+            session.stream.inner.written_buf == command.as_bytes().to_vec(),
+            "Invalid NOOP command"
+        );
+    }
 }

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -105,7 +105,11 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
                     self.decode_needs = 0;
                     Err(Some(io::Error::new(
                         io::ErrorKind::Other,
-                        format!("{:?} during parsing of {:?}", other, buf),
+                        format!(
+                            "{:?} during parsing of {:?}",
+                            other,
+                            String::from_utf8_lossy(buf)
+                        ),
                     )))
                 }
             }


### PR DESCRIPTION
Otherwise users get error messages
where unparseable server response
is printed as an array of bytes
such as
[50, 50, 48, 32, 109, 97, 105, 108, 46, 101, 120, 97, 109, 112, 108, 101, 46, 111, 114, 103, 32, 69, 83, 77, 84, 80, 32, 80, 111, 115, 116, 99, 111, 119]