### PR TITLE
fix: make handle_unilateral non-async

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1434,7 +1434,7 @@ impl<T: Read + Write + Unpin + fmt::Debug> Connection<T> {
             }
 
             if let Some(unsolicited) = unsolicited.clone() {
-                handle_unilateral(response, unsolicited).await;
+                handle_unilateral(response, unsolicited);
             }
 
             if let Some(res) = self.stream.next().await {

--- a/src/extensions/id.rs
+++ b/src/extensions/id.rs
@@ -56,7 +56,7 @@ pub(crate) async fn parse_id<T: Stream<Item = io::Result<ResponseData>> + Unpin>
                 })
             }
             _ => {
-                handle_unilateral(resp, unsolicited.clone()).await;
+                handle_unilateral(resp, unsolicited.clone());
             }
         }
     }

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -168,7 +168,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
                         // continuation, wait for it
                     }
                     Response::Done { .. } => {
-                        handle_unilateral(resp, sender.clone()).await;
+                        handle_unilateral(resp, sender.clone());
                     }
                     _ => return Ok(IdleResponse::NewData(resp)),
                 }
@@ -203,10 +203,10 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
                             .into());
                         }
                     }
-                    handle_unilateral(res, self.session.unsolicited_responses_tx.clone()).await;
+                    handle_unilateral(res, self.session.unsolicited_responses_tx.clone());
                 }
                 _ => {
-                    handle_unilateral(res, self.session.unsolicited_responses_tx.clone()).await;
+                    handle_unilateral(res, self.session.unsolicited_responses_tx.clone());
                 }
             }
         }

--- a/src/extensions/quota.rs
+++ b/src/extensions/quota.rs
@@ -30,7 +30,7 @@ pub(crate) async fn parse_get_quota<T: Stream<Item = io::Result<ResponseData>> +
         match resp.parsed() {
             Response::Quota(q) => quota = Some(q.clone().into()),
             _ => {
-                handle_unilateral(resp, unsolicited.clone()).await;
+                handle_unilateral(resp, unsolicited.clone());
             }
         }
     }
@@ -65,7 +65,7 @@ pub(crate) async fn parse_get_quota_root<T: Stream<Item = io::Result<ResponseDat
                 quotas.push(q.clone().into());
             }
             _ => {
-                handle_unilateral(resp, unsolicited.clone()).await;
+                handle_unilateral(resp, unsolicited.clone());
             }
         }
     }


### PR DESCRIPTION
The check for `unsolicited.is_full()`
at the beginning of `handle_unilateral`
is not sufficient if the function is called
from multiple threads parallel.
This normally should not happen,
but not guaranteed.

Instead of checking if the channel is full in advance, use `tr_send` and ignore the error
if the channel happens to be full
when we try to send into it.

We also ignore the error when the channel
is closed instead of panic
because the library should never panic.