### PR TITLE
fix: use write_all() to write space after a tag

### DIFF
--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -47,7 +47,7 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
 
         if let Some(tag) = msg.0 {
             self.inner.write_all(tag.as_bytes()).await?;
-            self.inner.write(b" ").await?;
+            self.inner.write_all(b" ").await?;
         }
         self.inner.write_all(&msg.1).await?;
         self.inner.write_all(b"\r\n").await?;


### PR DESCRIPTION
`write()` should not return Ok without writing anything, but the documentation is not clear on this
and underlying implementation may be wrong
as IMAP can be run over various streams,
e.g. compressed, encrypted, proxied.
It is safer to use `write_all()` everywhere,
even when we write a single byte.