### PR TITLE
feat: add APIs to get references to underlying stream

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1360,6 +1360,16 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Session<T> {
 impl<T: Read + Write + Unpin + fmt::Debug> Connection<T> {
     unsafe_pinned!(stream: ImapStream<T>);
 
+    /// Gets a reference to the underlying stream.
+    pub fn get_ref(&self) -> &T {
+        self.stream.get_ref()
+    }
+
+    /// Gets a mutable reference to the underlying stream.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.stream.get_mut()
+    }
+
     /// Convert this connection into the raw underlying stream.
     pub fn into_inner(self) -> T {
         let Self { stream, .. } = self;

--- a/src/imap_stream.rs
+++ b/src/imap_stream.rs
@@ -54,6 +54,17 @@ impl<R: Read + Write + Unpin> ImapStream<R> {
         Ok(())
     }
 
+    /// Gets a reference to the underlying stream.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying stream.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Returns underlying stream.
     pub fn into_inner(self) -> R {
         self.inner
     }


### PR DESCRIPTION
This can be useful for example to get access
to the peer address of the underlying TCP stream
for logging purposes.