### PR TITLE
refactor!: use try_next() more

### DIFF
--- a/examples/src/bin/integration.rs
+++ b/examples/src/bin/integration.rs
@@ -31,7 +31,7 @@ async fn session(user: &str) -> Result<Session<async_native_tls::TlsStream<TcpSt
     let mut client = async_imap::Client::new(tls_stream);
     let _greeting = client
         .read_response()
-        .await
+        .await?
         .context("unexpected end of stream, expected greeting")?;
 
     let session = client
@@ -48,7 +48,7 @@ async fn _connect_insecure_then_secure() -> Result<()> {
     let mut client = async_imap::Client::new(tcp_stream);
     let _greeting = client
         .read_response()
-        .await
+        .await?
         .context("unexpected end of stream, expected greeting")?;
     client.run_command_and_check_ok("STARTTLS", None).await?;
     let stream = client.into_inner();

--- a/src/extensions/id.rs
+++ b/src/extensions/id.rs
@@ -43,10 +43,9 @@ pub(crate) async fn parse_id<T: Stream<Item = io::Result<ResponseData>> + Unpin>
     let mut id = None;
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         match resp.parsed() {
             Response::Id(res) => {
                 id = res.as_ref().map(|m| {

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -182,8 +182,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
     pub async fn init(&mut self) -> Result<()> {
         let id = self.session.run_command("IDLE").await?;
         self.id = Some(id);
-        while let Some(res) = self.session.stream.next().await {
-            let res = res?;
+        while let Some(res) = self.session.stream.try_next().await? {
             match res.parsed() {
                 Response::Continue { .. } => {
                     return Ok(());

--- a/src/extensions/quota.rs
+++ b/src/extensions/quota.rs
@@ -23,10 +23,9 @@ pub(crate) async fn parse_get_quota<T: Stream<Item = io::Result<ResponseData>> +
     let mut quota = None;
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         match resp.parsed() {
             Response::Quota(q) => quota = Some(q.clone().into()),
             _ => {
@@ -53,10 +52,9 @@ pub(crate) async fn parse_get_quota_root<T: Stream<Item = io::Result<ResponseDat
 
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         match resp.parsed() {
             Response::QuotaRoot(qr) => {
                 roots.push(qr.clone().into());

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -99,8 +99,7 @@ pub(crate) async fn parse_status<T: Stream<Item = io::Result<ResponseData>> + Un
 ) -> Result<Mailbox> {
     let mut mbox = Mailbox::default();
 
-    while let Some(resp) = stream.next().await {
-        let resp = resp?;
+    while let Some(resp) = stream.try_next().await? {
         match resp.parsed() {
             Response::Done {
                 tag,
@@ -192,10 +191,9 @@ pub(crate) async fn parse_capabilities<T: Stream<Item = io::Result<ResponseData>
 
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         match resp.parsed() {
             Response::Capabilities(cs) => {
                 for c in cs {
@@ -218,10 +216,9 @@ pub(crate) async fn parse_noop<T: Stream<Item = io::Result<ResponseData>> + Unpi
 ) -> Result<()> {
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         handle_unilateral(resp, unsolicited.clone());
     }
 
@@ -235,8 +232,7 @@ pub(crate) async fn parse_mailbox<T: Stream<Item = io::Result<ResponseData>> + U
 ) -> Result<Mailbox> {
     let mut mailbox = Mailbox::default();
 
-    while let Some(resp) = stream.next().await {
-        let resp = resp?;
+    while let Some(resp) = stream.try_next().await? {
         match resp.parsed() {
             Response::Done {
                 tag,
@@ -345,10 +341,9 @@ pub(crate) async fn parse_ids<T: Stream<Item = io::Result<ResponseData>> + Unpin
 
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         match resp.parsed() {
             Response::MailboxData(MailboxDatum::Search(cs)) => {
                 for c in cs {
@@ -374,10 +369,9 @@ pub(crate) async fn parse_metadata<T: Stream<Item = io::Result<ResponseData>> + 
     let mut res_values = Vec::new();
     while let Some(resp) = stream
         .take_while(|res| filter(res, &command_tag))
-        .next()
-        .await
+        .try_next()
+        .await?
     {
-        let resp = resp?;
         match resp.parsed() {
             // METADATA Response with Values
             // <https://datatracker.ietf.org/doc/html/rfc5464.html#section-4.4.1>


### PR DESCRIPTION
I have looked through the code
to make sure errors are not ignored,
especially in loops.
Ignoring errors in loops
when reading from streams
may result in infinite loop
reading the same error over and over again.
No bugs found,
but I refactored reading from streams
to use `try_next()` more
to bubble up the errors with `?`
as soon as possible.

This is a breaking change since
`read_response()` is resultified to return `Result<Option<_>>` instead of `Option<Result<_>>`.
`read_response()` is a public interface
that is used by library users
to read the banner.