### PR TITLE
fix: crate::extensions::idle::Handle::wait() uses a 29 minute timeout

### DIFF
--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -120,7 +120,7 @@ impl<T: Read + Write + Unpin + fmt::Debug + Send> Handle<T> {
         impl Future<Output = Result<IdleResponse>> + '_,
         stop_token::StopSource,
     ) {
-        self.wait_with_timeout(Duration::from_secs(24 * 60 * 60))
+        self.wait_with_timeout(Duration::from_secs(29 * 60))
     }
 
     /// Start listening to the server side responses.


### PR DESCRIPTION
The timeout was incorrectly set to 24 hours. This has been changed to 29 minutes to reflect the documentation on Handle struct and the reccomendation in RFC 2177.