### PR TITLE
Add gmail_thr_id() accessor for X-GM-THRID

### DIFF
--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -266,4 +266,22 @@ impl Fetch {
             unreachable!()
         }
     }
+
+    /// Extract the `X-GM-THRID` of a `FETCH` response
+    ///
+    /// See [Access to Gmail thread IDs: X-GM-THRID](https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_thread_ids_x-gm-thrid)
+    /// for details.
+    pub fn gmail_thr_id(&self) -> Option<&u64> {
+        if let Response::Fetch(_, attrs) = self.response.parsed() {
+            attrs
+                .iter()
+                .filter_map(|av| match av {
+                    AttributeValue::GmailThrId(id) => Some(id),
+                    _ => None,
+                })
+                .next()
+        } else {
+            unreachable!()
+        }
+    }
 }


### PR DESCRIPTION
The underlying `imap-proto` parser already handles `X-GM-THRID` (`GmailThrId` `AttributeValue`), but the `Fetch` struct only exposed `gmail_msg_id()` and `gmail_labels()`. This adds the matching accessor for Gmail thread IDs, following the same pattern.

See [Access to Gmail thread IDs: X-GM-THRID](https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_thread_ids_x-gm-thrid) for details on the extension.