### PR TITLE
Expose X-GM-THRID via Fetch::gmail_thread_id()

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -570,6 +570,28 @@ mod tests {
 
     #[cfg_attr(feature = "runtime-tokio", tokio::test)]
     #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    async fn parse_fetches_gmail_thread_id() {
+        let (send, recv) = bounded(10);
+        let responses = input_stream(&[
+            "* 24 FETCH (FLAGS (\\Seen) UID 4827943 X-GM-THRID 1278455344230334865)\r\n",
+            "* 25 FETCH (FLAGS (\\Seen))\r\n",
+        ]);
+        let mut stream = async_std::stream::from_iter(responses);
+        let id = RequestId("a".into());
+
+        let fetches = parse_fetches(&mut stream, send, id)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert!(recv.is_empty());
+
+        assert_eq!(fetches.len(), 2);
+        assert_eq!(fetches[0].gmail_thread_id(), Some(&1278455344230334865));
+        assert_eq!(fetches[1].gmail_thread_id(), None);
+    }
+
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
     async fn parse_fetches_w_unilateral() {
         // https://github.com/mattnenterprise/rust-imap/issues/81
         let (send, recv) = bounded(10);

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -266,4 +266,20 @@ impl Fetch {
             unreachable!()
         }
     }
+
+    /// Get the Gmail thread id (X-GM-THRID). Only present if the server
+    /// returned it (Gmail's X-GM-EXT-1).
+    pub fn gmail_thread_id(&self) -> Option<&u64> {
+        if let Response::Fetch(_, attrs) = self.response.parsed() {
+            attrs
+                .iter()
+                .filter_map(|av| match av {
+                    AttributeValue::GmailThrId(id) => Some(id),
+                    _ => None,
+                })
+                .next()
+        } else {
+            unreachable!()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`imap-proto` already parses the Gmail thread id (`X-GM-THRID`) into `AttributeValue::GmailThrId`, but `Fetch` provided no getter for it — unlike its siblings `gmail_msg_id()` (`X-GM-MSGID`) and `gmail_labels()` (`X-GM-LABELS`). This adds the missing accessor:

```rust
/// Get the Gmail thread id (X-GM-THRID). Only present if the server
/// returned it (Gmail's X-GM-EXT-1).
pub fn gmail_thread_id(&self) -> Option<&u64>
```

It mirrors `gmail_msg_id()` exactly, just matching `AttributeValue::GmailThrId` instead of `AttributeValue::GmailMsgId`.

**Motivation:** `X-GM-THRID` lets clients group messages into Gmail conversations/threads without re-implementing Gmail's threading heuristics. Since `gmail_msg_id`/`gmail_labels` are already exposed, this fills the gap for the one remaining Gmail extension attribute `imap-proto` parses.

## Test plan

- Added `parse_fetches_gmail_thread_id` in `src/parse.rs`, following the existing `parse_fetches_test` convention: feeds a `* 24 FETCH (... X-GM-THRID 1278455344230334865)` response through `parse_fetches` and asserts `gmail_thread_id()` returns the parsed value, and `None` for a FETCH response without it.
- `cargo fmt --check` and `cargo test --features runtime-async-std` pass (70 unit tests, including the new one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
